### PR TITLE
Add unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ project('ripc-transport-netty4') {
     // ripc-tcp
     compile project(":ripc-protocol-tcp"),
         "io.netty:netty-all:$nettyVersion"
+    testCompile project(":ripc-test")
   }
 }
 
@@ -135,6 +136,8 @@ project('ripc-rxjava1') {
     compile project(":ripc-protocol-tcp"),
         "io.reactivex:rxjava:$rxjava1Version",
         "io.reactivex:rxjava-reactive-streams:$rxjavaRsVersion"
+    testCompile project(":ripc-transport-netty4"),
+            project(":ripc-test")
   }
 }
 
@@ -144,6 +147,8 @@ project('ripc-reactor') {
     // ripc-tcp
     compile project(":ripc-protocol-tcp"),
         "io.projectreactor:reactor-stream:$reactorVersion"
+    testCompile project(":ripc-transport-netty4"),
+            project(":ripc-test")
   }
 }
 
@@ -166,6 +171,14 @@ project('ripc-reactor-examples') {
         project(":ripc-transport-netty4")
 
     runtime "ch.qos.logback:logback-classic:$logbackVersion"
+  }
+}
+
+project('ripc-test') {
+  description = 'Reactive IPC Test Components'
+  dependencies {
+    // Reactive Streams
+    compile "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ ext {
   ] as String[]
 }
 
+def exampleProjects = [ project(':ripc-transport-netty4-examples'),
+                        project(':ripc-rxjava1-examples'),
+                        project(':ripc-reactor-examples') ]
+
 allprojects {
   apply plugin: 'java'
 
@@ -77,6 +81,14 @@ subprojects { subproject ->
     testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
   }
 }
+
+configure(exampleProjects) {
+  compileJava {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+  }
+}
+
 
 project('ripc-core') {
   description = 'Reactive IPC Core Components'
@@ -131,7 +143,7 @@ project('ripc-reactor') {
   dependencies {
     // ripc-tcp
     compile project(":ripc-protocol-tcp"),
-        "io.projectreactor:reactor-net:$reactorVersion"
+        "io.projectreactor:reactor-stream:$reactorVersion"
   }
 }
 

--- a/ripc-core/src/main/java/io/ripc/internal/Publishers.java
+++ b/ripc-core/src/main/java/io/ripc/internal/Publishers.java
@@ -9,14 +9,16 @@ import org.reactivestreams.Subscription;
  */
 public class Publishers {
 
-    public static <T> Publisher<T> just(final T value) {
+    public static <T> Publisher<T> just(final T... values) {
         return new Publisher<T>() {
             @Override
             public void subscribe(final Subscriber<? super T> s) {
                 s.onSubscribe(new Subscription() {
                     @Override
                     public void request(long n) {
-                        s.onNext(value);
+                        for (T value : values) {
+                            s.onNext(value);
+                        }
                         s.onComplete();
                     }
 

--- a/ripc-protocol-tcp/src/main/java/io/ripc/protocol/tcp/TcpServer.java
+++ b/ripc-protocol-tcp/src/main/java/io/ripc/protocol/tcp/TcpServer.java
@@ -36,4 +36,6 @@ public abstract class TcpServer<R, W> {
 
     protected abstract TcpServer<R, W> doStart(TcpHandler<R, W> handler);
 
+    public abstract int getPort();
+
 }

--- a/ripc-reactor-examples/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServerSample.java
+++ b/ripc-reactor-examples/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServerSample.java
@@ -12,14 +12,15 @@ import java.nio.charset.Charset;
  * Created by jbrisbin on 5/28/15.
  */
 public class ReactorTcpServerSample {
+
     public static void main(String... args) throws InterruptedException {
         TcpServer<ByteBuf, ByteBuf> transport = Netty4TcpServer.<ByteBuf, ByteBuf>create(0);
 
         ReactorTcpServer.create(transport)
-                        .start(ch -> ch.flatMap(bb -> {
+                        .start(connection -> connection.flatMap(bb -> {
                             String msgStr = "Hello " + bb.toString(Charset.defaultCharset()) + "!";
                             ByteBuf msg = Unpooled.buffer().writeBytes(msgStr.getBytes());
-                            return ch.writeWith(Streams.just(msg));
+                            return connection.writeWith(Streams.just(msg));
                         }));
     }
 

--- a/ripc-reactor-examples/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServerSample.java
+++ b/ripc-reactor-examples/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServerSample.java
@@ -17,7 +17,7 @@ public class ReactorTcpServerSample {
         TcpServer<ByteBuf, ByteBuf> transport = Netty4TcpServer.<ByteBuf, ByteBuf>create(0);
 
         ReactorTcpServer.create(transport)
-                        .start(connection -> connection.flatMap(bb -> {
+                        .startAndAwait(connection -> connection.flatMap(bb -> {
                             String msgStr = "Hello " + bb.toString(Charset.defaultCharset()) + "!";
                             ByteBuf msg = Unpooled.buffer().writeBytes(msgStr.getBytes());
                             return connection.writeWith(Streams.just(msg));

--- a/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpConnection.java
+++ b/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpConnection.java
@@ -13,7 +13,6 @@ public class ReactorTcpConnection<R, W> extends Stream<R> {
     private final TcpConnection<R, W> transport;
 
     public ReactorTcpConnection(TcpConnection<R, W> transport) {
-        super();
         this.transport = transport;
     }
 

--- a/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpHandler.java
+++ b/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpHandler.java
@@ -1,0 +1,8 @@
+package io.ripc.reactor.protocol.tcp;
+
+import org.reactivestreams.Publisher;
+import reactor.fn.Function;
+
+public interface ReactorTcpHandler<R, W> extends Function<ReactorTcpConnection<R, W>, Publisher<Void>> {
+
+}

--- a/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServer.java
+++ b/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServer.java
@@ -24,6 +24,17 @@ public class ReactorTcpServer<R, W> {
 
     public ReactorTcpServer<R, W> start(final ReactorTcpHandler<R, W> handler) {
 
+        transport.start(new TcpHandler<R, W>() {
+            @Override
+            public Publisher<Void> handle(TcpConnection<R, W> connection) {
+                return handler.apply(new ReactorTcpConnection<>(connection));
+            }
+        });
+        return this;
+    }
+
+    public ReactorTcpServer<R, W> startAndAwait(final ReactorTcpHandler<R, W> handler) {
+
         transport.startAndAwait(new TcpHandler<R, W>() {
             @Override
             public Publisher<Void> handle(TcpConnection<R, W> connection) {
@@ -37,6 +48,10 @@ public class ReactorTcpServer<R, W> {
         boolean b = transport.shutdown();
         transport.awaitShutdown();
         return b;
+    }
+
+    public int getPort() {
+        return transport.getPort();
     }
 
     public static <R, W> ReactorTcpServer<R, W> create(TcpServer<R, W> transport) {

--- a/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServer.java
+++ b/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServer.java
@@ -1,5 +1,7 @@
 package io.ripc.reactor.protocol.tcp;
 
+import io.ripc.protocol.tcp.TcpConnection;
+import io.ripc.protocol.tcp.TcpHandler;
 import io.ripc.protocol.tcp.TcpServer;
 import org.reactivestreams.Publisher;
 import reactor.Environment;
@@ -20,8 +22,14 @@ public class ReactorTcpServer<R, W> {
         this.transport = transport;
     }
 
-    public ReactorTcpServer<R, W> start(Function<ReactorTcpConnection<R, W>, Publisher<Void>> handler) {
-        transport.startAndAwait(conn -> handler.apply(new ReactorTcpConnection<>(conn)));
+    public ReactorTcpServer<R, W> start(ReactorTcpHandler<R, W> handler) {
+
+        transport.startAndAwait(new TcpHandler<R, W>() {
+            @Override
+            public Publisher<Void> handle(TcpConnection<R, W> connection) {
+                return handler.apply(new ReactorTcpConnection<>(connection));
+            }
+        });
         return this;
     }
 

--- a/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServer.java
+++ b/ripc-reactor/src/main/java/io/ripc/reactor/protocol/tcp/ReactorTcpServer.java
@@ -22,7 +22,7 @@ public class ReactorTcpServer<R, W> {
         this.transport = transport;
     }
 
-    public ReactorTcpServer<R, W> start(ReactorTcpHandler<R, W> handler) {
+    public ReactorTcpServer<R, W> start(final ReactorTcpHandler<R, W> handler) {
 
         transport.startAndAwait(new TcpHandler<R, W>() {
             @Override

--- a/ripc-reactor/src/test/java/io/ripc/reactor/ReactorTcpServerTests.java
+++ b/ripc-reactor/src/test/java/io/ripc/reactor/ReactorTcpServerTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ripc.reactor;
+
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.ripc.reactor.protocol.tcp.ReactorTcpServer;
+import io.ripc.test.SocketTestUtils;
+import io.ripc.transport.netty4.tcp.Netty4TcpServer;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.rx.Promise;
+import reactor.rx.Promises;
+import reactor.rx.Streams;
+
+public class ReactorTcpServerTests {
+
+    private ReactorTcpServer<ByteBuf, ByteBuf> reactorServer;
+
+    @Before
+    public void setup() {
+        reactorServer =  ReactorTcpServer.create(Netty4TcpServer.<ByteBuf, ByteBuf>create(0));
+    }
+
+    @After
+    public void tearDown() {
+        reactorServer.shutdown();
+    }
+
+    @Test
+    public void writeSingleValue() throws IOException {
+        reactorServer.start(connection -> connection.writeWith(Streams.just(Unpooled.buffer().writeBytes("test".getBytes()))));
+        assertEquals("test", SocketTestUtils.read("localhost", reactorServer.getPort()));
+    }
+
+    @Test
+    public void writeMultipleValues() throws IOException {
+        Promise<ByteBuf> chunk1 = Promises.success(Unpooled.buffer().writeBytes("This is".getBytes()));
+        Promise<ByteBuf> chunk2 = Promises.success(Unpooled.buffer().writeBytes(" a test!".getBytes()));
+        reactorServer.start(connection -> connection.writeWith(Streams.concat(chunk1, chunk2)));
+        assertEquals("This is a test!", SocketTestUtils.read("localhost", reactorServer.getPort()));
+    }
+
+}

--- a/ripc-rxjava1/src/main/java/io/ripc/rx/protocol/tcp/RxTcpServer.java
+++ b/ripc-rxjava1/src/main/java/io/ripc/rx/protocol/tcp/RxTcpServer.java
@@ -39,6 +39,10 @@ public final class RxTcpServer<R, W> {
         transport.awaitShutdown();
     }
 
+    public int getPort() {
+        return transport.getPort();
+    }
+
     public static <R, W> RxTcpServer<R, W> create(TcpServer<R, W> transport) {
         return new RxTcpServer<>(transport);
     }

--- a/ripc-rxjava1/src/test/java/io/ripc/rx/RxTcpServerTests.java
+++ b/ripc-rxjava1/src/test/java/io/ripc/rx/RxTcpServerTests.java
@@ -1,0 +1,58 @@
+package io.ripc.rx;/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.ripc.rx.protocol.tcp.RxTcpServer;
+import io.ripc.test.SocketTestUtils;
+import io.ripc.transport.netty4.tcp.Netty4TcpServer;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import rx.Observable;
+
+public class RxTcpServerTests {
+
+    private RxTcpServer<ByteBuf, ByteBuf> rxServer;
+
+    @Before
+    public void setup() {
+        rxServer =  RxTcpServer.create(Netty4TcpServer.<ByteBuf, ByteBuf>create(0));
+    }
+
+    @After
+    public void tearDown() {
+        rxServer.shutdown();
+    }
+
+    @Test
+    public void writeSingleValue() throws IOException {
+        rxServer.start(connection -> connection.write(Observable.just(Unpooled.buffer().writeBytes("test".getBytes()))));
+        assertEquals("test", SocketTestUtils.read("localhost", rxServer.getPort()));
+    }
+
+    @Test
+    public void writeMultipleValues() throws IOException {
+        Observable<ByteBuf> chunk1 = Observable.just(Unpooled.buffer().writeBytes("This is".getBytes()));
+        Observable<ByteBuf> chunk2 = Observable.just(Unpooled.buffer().writeBytes(" a test!".getBytes()));
+        rxServer.start(connection -> connection.write(Observable.merge(chunk1, chunk2)));
+        assertEquals("This is a test!", SocketTestUtils.read("localhost", rxServer.getPort()));
+    }
+
+}

--- a/ripc-test/src/main/java/io/ripc/test/SocketTestUtils.java
+++ b/ripc-test/src/main/java/io/ripc/test/SocketTestUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ripc.test;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Socket;
+
+public class SocketTestUtils {
+
+    public static String read(String host, int port) {
+        return read(host, port, null);
+    }
+
+    public static String read(String host, int port, String dataToSend) {
+        try {
+            Socket socket = new Socket(host, port);
+            InputStreamReader reader = new InputStreamReader(socket.getInputStream());
+            if (dataToSend != null) {
+                DataOutputStream outputStream = new DataOutputStream(socket.getOutputStream());
+                outputStream.writeBytes(dataToSend);
+            }
+            StringBuilder content = new StringBuilder();
+            int c = reader.read();
+            while (c != -1) {
+                content.append((char)c);
+                c = reader.read();
+            }
+            reader.close();
+            return content.toString();
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/ripc-transport-netty4/src/main/java/io/ripc/transport/netty4/tcp/Netty4TcpServer.java
+++ b/ripc-transport-netty4/src/main/java/io/ripc/transport/netty4/tcp/Netty4TcpServer.java
@@ -18,7 +18,7 @@ public class Netty4TcpServer<R, W> extends TcpServer<R, W> {
 
     private static final Logger logger = LoggerFactory.getLogger(Netty4TcpServer.class);
 
-    private final int port;
+    private int port;
     private ServerBootstrap bootstrap;
     private ChannelFuture bindFuture;
 
@@ -45,7 +45,8 @@ public class Netty4TcpServer<R, W> extends TcpServer<R, W> {
             }
             SocketAddress localAddress = bindFuture.channel().localAddress();
             if (localAddress instanceof InetSocketAddress) {
-                logger.info("Started server at port: " + ((InetSocketAddress) localAddress).getPort());
+                port = ((InetSocketAddress) localAddress).getPort();
+                logger.info("Started server at port: " + port);
             }
 
         } catch (InterruptedException e) {
@@ -74,6 +75,11 @@ public class Netty4TcpServer<R, W> extends TcpServer<R, W> {
             logger.error("Failed to shutdown the server.", e);
             return false;
         }
+    }
+
+    @Override
+    public int getPort() {
+        return port;
     }
 
     public static <R, W> TcpServer<R, W> create(int port) {

--- a/ripc-transport-netty4/src/test/java/io/ripc/transport/netty4/TcpServerTests.java
+++ b/ripc-transport-netty4/src/test/java/io/ripc/transport/netty4/TcpServerTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ripc.transport.netty4;
+
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.ripc.internal.Publishers;
+import io.ripc.protocol.tcp.TcpServer;
+import io.ripc.test.SocketTestUtils;
+import io.ripc.transport.netty4.tcp.Netty4TcpServer;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TcpServerTests {
+
+    private TcpServer<ByteBuf, ByteBuf> server;
+
+    @Before
+    public void setup() {
+        server =  Netty4TcpServer.<ByteBuf, ByteBuf>create(0);
+    }
+
+    @After
+    public void tearDown() {
+        server.shutdown();
+    }
+
+    @Test
+    public void writeSingleValue() throws IOException {
+        server.start(connection -> connection.write(Publishers.just(Unpooled.buffer().writeBytes("test".getBytes()))));
+        assertEquals("test", SocketTestUtils.read("localhost", server.getPort()));
+    }
+
+    @Test
+    public void writeMultipleValues() throws IOException {
+        server.start(connection -> {
+            ByteBuf chunk1 = Unpooled.buffer().writeBytes("This is".getBytes());
+            ByteBuf chunk2 = Unpooled.buffer().writeBytes(" a test!".getBytes());
+                return connection.write(Publishers.just(chunk1, chunk2));
+        });
+        assertEquals("This is a test!", SocketTestUtils.read("localhost", server.getPort()));
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,5 @@ include 'ripc-core',
         'ripc-reactor',
         'ripc-rxjava1',
         'ripc-reactor-examples',
-        'ripc-rxjava1-examples'
+        'ripc-rxjava1-examples',
+        'ripc-test'


### PR DESCRIPTION
This commit adds basic unit tests for `ripc-transport-netty4`, `ripc-rxjava1` and `ripc-reactor` modules.
